### PR TITLE
Annotate tags by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 2
-      - uses: salsify/action-detect-and-tag-new-version@v1
+      - uses: salsify/action-detect-and-tag-new-version@v2
         with:
           version-command: |
             cat current-version.txt
@@ -35,6 +35,10 @@ All inputs are optional.
  - `create-tag`: may be set to `false` to only detect version changes and not create a new tag when the version changes.
  - `tag-template`: a template for producing a tag name from the current version of your repository. Any instance of
    `{VERSION}` in the string will be replaced with the actual detected version. Defaults to `v{VERSION}`.
+ - `tag-annotation-template`: a template for producing a tag annotation from the current version of your repository. As
+   with `tag-template`, any instance of `{VERSION}` in the string will be replaced with the actual detected version.
+   May be set to an empty string to produce a lightweight (i.e. annotation-less) tag. Defaults to
+   `Released version {VERSION}`.
 
 ### Outputs
 

--- a/__tests__/git.test.ts
+++ b/__tests__/git.test.ts
@@ -46,12 +46,12 @@ describe('createTag', () => {
     await initRepository('upstream');
     await addAndTrackRemote('foo', 'upstream/.git');
 
-    await git.createTag('foo-bar');
+    await git.createTag('foo-bar', 'Here is my commit annotation.');
 
-    let localTag = await execa('git', ['tag']);
-    expect(localTag.stdout.trim()).toBe('foo-bar');
+    let localTag = await execa('git', ['tag', '-n1']);
+    expect(localTag.stdout.trim()).toMatch(/^foo-bar\s+Here is my commit annotation.$/);
 
-    let remoteTag = await execa('git', ['tag'], { cwd: 'upstream' });
-    expect(remoteTag.stdout.trim()).toBe('foo-bar');
+    let remoteTag = await execa('git', ['tag', '-n1'], { cwd: 'upstream' });
+    expect(remoteTag.stdout.trim()).toMatch(/^foo-bar\s+Here is my commit annotation.$/);
   });
 });

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,12 @@ inputs:
       A template for producing a tag name from the current version of your
       repository, replacing '{VERSION}' with the deteced version.
     default: 'v{VERSION}'
+  tag-annotation-template:
+    description: >
+      A template for producing a tag annotation from the current version of your
+      repository, replacing '{VERSION}' with the deteced version. May be set to
+      an empty string to produce a lightweight (i.e. annotation-less) tag.
+    default: 'Released version {VERSION}'
 outputs:
   previous-version:
     description: the detected previous version of this repository

--- a/src/git.ts
+++ b/src/git.ts
@@ -25,7 +25,12 @@ export async function checkout(ref: string): Promise<void> {
   await execa('git', ['checkout', ref]);
 }
 
-export async function createTag(name: string): Promise<void> {
-  await execa('git', ['tag', name]);
+export async function createTag(name: string, annotation: string): Promise<void> {
+  let tagArgs = ['tag', name];
+  if (annotation.length) {
+    tagArgs.push('-m', annotation);
+  }
+
+  await execa('git', tagArgs);
   await execa('git', ['push', '--tags']);
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,8 @@ import { determineVersion } from './determine-version';
 import { validateHistoryDepth, checkout, createTag, refExists } from './git';
 import { getEnv } from './utils';
 
+const VERSION_PLACEHOLDER = /{VERSION}/g;
+
 async function run(): Promise<void> {
   await validateHistoryDepth();
   await checkout('HEAD~1');
@@ -21,7 +23,10 @@ async function run(): Promise<void> {
 
   if (currentVersion !== previousVersion && getInput('create-tag') !== 'false') {
     let tagTemplate = getInput('tag-template') || 'v{VERSION}';
-    let tag = tagTemplate.replace(/{VERSION}/g, currentVersion);
+    let tag = tagTemplate.replace(VERSION_PLACEHOLDER, currentVersion);
+
+    let annotationTemplate = getInput('tag-annotation-template') || 'Released version {VERSION}';
+    let annotation = annotationTemplate.replace(VERSION_PLACEHOLDER, currentVersion);
 
     if (await refExists(tag)) {
       info(`Tag ${tag} already exists`);
@@ -29,7 +34,7 @@ async function run(): Promise<void> {
       info(`Creating tag ${tag}`);
       setOutput('tag', tag);
 
-      await createTag(tag);
+      await createTag(tag, annotation);
     }
   }
 }


### PR DESCRIPTION
The v1 release of this action produced lightweight tags, but there [are arguments to be made](https://stackoverflow.com/questions/4971746/why-should-i-care-about-lightweight-vs-annotated-tags/4971817) in favor of defaulting to annotated tags for things like releases. They also play more nicely with Lerna's change detection when publishing new versions of monorepo packages.

This PR updates the action to produce annotated tags by default, with the option to go back to using lightweight tags instead by providing an empty `annotation-template` input. This will become v2 of the action, since default behavior is changing.