### PR TITLE
Allow blank tag-annotation-template

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -25,7 +25,7 @@ async function run(): Promise<void> {
     let tagTemplate = getInput('tag-template') || 'v{VERSION}';
     let tag = tagTemplate.replace(VERSION_PLACEHOLDER, currentVersion);
 
-    let annotationTemplate = getInput('tag-annotation-template') || 'Released version {VERSION}';
+    let annotationTemplate = getInput('tag-annotation-template') || '';
     let annotation = annotationTemplate.replace(VERSION_PLACEHOLDER, currentVersion);
 
     if (await refExists(tag)) {


### PR DESCRIPTION
I have `tag-annotation-template: ''` and it is just ignored and the default is used. I know im doing it right because if i have anything in the string it works. 
```
let annotationTemplate = getInput('tag-annotation-template') || 'Released version {VERSION}';
```
this line is whats causing the problem when `getInput('tag-annotation-template')` is blank its considered false and just defaults to 
`Released version {VERSION}` so there's no way to not have an annotation

my current workaround is to just use v1.0.3 which doesn't have annotations at all
`uses: salsify/action-detect-and-tag-new-version@v1.0.3`

personally i think you should just change it to 

```
let annotationTemplate = getInput('tag-annotation-template') || '';
```

and let the default operation have no annotation and let users add an annotation if they want by specifying `tag-annotation-template`